### PR TITLE
Registra commits e PRs pelo olhar do jogador

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,120 @@
+<!--
+Escreva este PR como a história de uma mudança no jogo, não como uma lista de arquivos.
+Priorize o que pode ser visto, ouvido, jogado ou sentido. Remova apenas seções que não se aplicam.
+Se não houver impacto direto para o jogador, declare isso sem inventar benefícios e explique o que o trabalho viabiliza.
+-->
+
+## Resumo para o jogador
+
+<!-- Em 2 a 4 frases, explique o que mudou como se estivesse contando a novidade a quem joga Daratrine. Diferencie fato verificado de resultado esperado. -->
+
+## A experiência: antes e agora
+
+**Antes:**
+
+<!-- Como esse momento funcionava, qual problema existia ou o que ainda não estava disponível? -->
+
+**Agora:**
+
+<!-- O que o jogador consegue fazer, perceber, decidir ou sentir depois deste PR? -->
+
+**Por que isso importa:**
+
+<!-- Relacione a mudança a estratégia, clareza, ritmo, emoção, fantasia do personagem ou progressão. -->
+
+## O que o jogador encontra
+
+<!-- Liste entregas observáveis. Prefira comportamentos e momentos do jogo a nomes de arquivos. -->
+
+-
+
+## Como experimentar
+
+<!-- Diga como chegar ao conteúdo: save recomendado, mapa, batalha, personagem, pré-condições e passos. -->
+
+1.
+
+## Evidências
+
+<!-- Inclua imagens, GIFs ou vídeos com legenda. Compare antes/depois quando isso tornar a mudança mais clara. -->
+
+| Momento | Evidência |
+| ------- | --------- |
+|         |           |
+
+## Decisões de design
+
+<!--
+Explique somente o que ajuda a entender a experiência final.
+Para combate, considere Efeito, Tempo/ATB, Recurso/TP, identidade do personagem e sinergias.
+Para narrativa, considere intenção da cena, escolha, consequência, ritmo e apresentação.
+-->
+
+-
+
+## Validação
+
+### Jornada jogada
+
+<!-- Registre cenários reais, incluindo resultado esperado e observado. Não marque uma verificação que não foi executada. -->
+
+- [ ] Fluxo principal:
+- [ ] Situação limite ou regressão relevante:
+
+### Verificações técnicas
+
+<!-- Inclua testes automatizados, playtest, lint/build e dispositivos ou saves usados. -->
+
+- [ ] Testes automatizados aplicáveis passaram
+- [ ] Playtest no RPG Maker MZ realizado
+- [ ] Save existente ou compatibilidade verificada, quando aplicável
+- [ ] Não verificado: <!-- explique o que falta validar, se aplicável -->
+
+## Fora deste PR
+
+<!-- Pendências, limitações conhecidas, conteúdo temporário e ideias futuras. Escreva "Nada conhecido" se estiver vazio. -->
+
+-
+
+## Kit de devlog
+
+<!-- Esta seção deve permitir montar um vídeo sem reler todo o diff. -->
+
+**Gancho em uma frase:**
+
+<!-- Ex.: "Thorin agora transforma preparação em uma janela decisiva de dano." -->
+
+**História curta da mudança:**
+
+<!-- Problema/desafio -> escolha feita -> resultado no jogo. Use 3 a 5 pontos. -->
+
+1.
+
+**Capturas sugeridas:**
+
+- [ ] O problema ou comportamento anterior
+- [ ] A novidade funcionando em jogo
+- [ ] Um detalhe de design ou bastidor relevante
+- [ ] O resultado completo do ponto de vista do jogador
+
+**Créditos e fontes:**
+
+<!-- Assets, música, plugins, referências ou colaboradores que devem aparecer no vídeo. -->
+
+-
+
+## Bastidores técnicos
+
+<!-- Arquitetura, plugins, dados, migrações e principais arquivos. Seja conciso e explique decisões incomuns. -->
+
+-
+
+## Checklist do autor
+
+- [ ] O título descreve um resultado perceptível, não apenas a tarefa executada
+- [ ] O resumo pode ser entendido sem conhecer o código
+- [ ] As alegações sobre o jogo foram verificadas em playtest ou marcadas como não verificadas
+- [ ] Mudanças sem impacto direto não receberam benefícios inventados
+- [ ] Evidências visuais foram anexadas quando a mudança pode ser demonstrada
+- [ ] Pendências e limitações estão explícitas
+- [ ] Dados sensíveis, saves pessoais e artefatos temporários não entraram no PR

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,26 @@
+<tipo>(<escopo opcional>): <resultado perceptível em até 72 caracteres>
+
+Experiência do jogador:
+- Antes: <como esse momento funcionava ou o que estava faltando>
+- Agora: <o que o jogador pode fazer, ver, ouvir, decidir ou sentir>
+- Por que importa: <impacto na diversão, clareza, ritmo, estratégia ou história>
+
+Validação:
+- [ ] <cenário jogado ou verificação executada; marque como não verificado quando necessário>
+
+Bastidores:
+- <decisão técnica ou de design que vale preservar; evite apenas listar arquivos>
+
+Material para devlog:
+- Momento demonstrável: <cena, batalha, menu, mapa ou fluxo>
+- Captura sugerida: <imagem ou clipe que evidencia a mudança>
+
+Limitações:
+- <risco, pendência ou "Nenhuma conhecida">
+
+# Tipos sugeridos: feat, fix, balance, narrative, ui, audio, refactor, test, docs, chore.
+# Escreva primeiro sobre o jogo; nomes de arquivos, classes e plugins ficam em Bastidores.
+# Use fatos observáveis. Não diga apenas "melhora", "ajusta" ou "implementa" sem explicar o efeito.
+# Se não houver impacto direto no jogo, escreva isso e explique qual trabalho futuro foi viabilizado. Não invente impacto.
+# Remova campos que realmente não se aplicam, mas preserve Experiência do jogador e Validação.
+# Linhas iniciadas por # não farão parte da mensagem final.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,11 @@ Configuracoes que afetam todo o sistema de combate e devem ser consideradas em d
 
 - Sempre dar prefencia por notetags VisuStella ou Coreto.
 - Procurar em `docs/rpg-maker-for-ia` se já existe algum plugin VisuStella que resolve o problema.
+
+# Mensagens de Commit e Pull Request
+
+- Ao preparar uma mensagem de commit, seguir `.gitmessage`, mesmo quando o commit for criado com `-m` ou por uma ferramenta que não abra o template automaticamente.
+- Ao preparar um pull request, seguir `.github/pull_request_template.md` e priorizar o resultado observável do ponto de vista do jogador.
+- Explicar a experiência antes e depois, por que a mudança importa, como foi validada e quais capturas podem demonstrá-la em um devlog.
+- Se uma alteração não tiver impacto direto para o jogador, declarar isso e explicar o que ela viabiliza. Nunca inventar um benefício para preencher o template.
+- Não afirmar que houve playtest, teste, captura ou validação sem evidência de que a atividade foi realmente executada.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contribuindo com Daratrine
+
+As mensagens de commit e os pull requests devem registrar primeiro a mudança do ponto de vista do jogador. Detalhes de código continuam importantes, mas entram como contexto para explicar como a
+experiência foi construída.
+
+## Ativar o template de commit
+
+Depois de clonar o repositório, execute uma vez, a partir de qualquer pasta do projeto:
+
+```sh
+git config --local commit.template "$(git rev-parse --show-toplevel)/.gitmessage"
+```
+
+O arquivo [`.gitmessage`](.gitmessage) será aberto pelo Git ao criar um commit sem a opção `-m`. Editores e clientes gráficos podem exigir que a criação do commit seja aberta no editor para exibir o
+template.
+
+O template de pull request em [`.github/pull_request_template.md`](.github/pull_request_template.md) é carregado automaticamente ao abrir um novo PR no GitHub.
+
+## Princípio de escrita
+
+Use esta ordem:
+
+1. O que mudou para o jogador.
+2. Por que isso melhora ou altera a experiência.
+3. Como a mudança foi validada.
+4. Quais decisões técnicas ou de design precisam ficar registradas.
+5. Que imagens e momentos ajudam a contar essa história em um devlog.
+
+Evite mensagens como `ajustes`, `polimento` ou `implementa sistema` sem explicar o resultado observável. Uma boa descrição permite que alguém entenda e demonstre a entrega sem precisar reconstruir a
+intenção a partir do diff.
+
+Quando uma alteração for apenas técnica, documental ou preparatória, declare que ela não muda diretamente a experiência atual e explique o que foi viabilizado. Nunca atribua ao jogador um benefício
+que não foi observado ou validado.
+
+## Exemplo curto de commit
+
+```text
+feat(combate): permite à Filena converter Momentum em turnos agressivos
+
+Experiência do jogador:
+- Antes: acumular Momentum não criava uma decisão clara de explosão.
+- Agora: Filena pode gastar o recurso para antecipar uma sequência ofensiva.
+- Por que importa: o jogador escolhe entre manter consistência ou acelerar o combate.
+
+Validação:
+- [x] A habilidade foi usada com TP baixo, médio e máximo em playtest.
+
+Bastidores:
+- A geração continua seguindo o TP Mode da Filena; a skill altera apenas o gasto e o efeito.
+
+Material para devlog:
+- Momento demonstrável: comparação do gauge ATB antes e depois da ativação.
+- Captura sugerida: clipe curto mostrando o turno extra e o custo de Momentum.
+
+Limitações:
+- Números de balanceamento ainda podem mudar depois dos testes com chefes.
+```


### PR DESCRIPTION
## Resumo para o jogador

Esta entrega não altera diretamente o conteúdo jogável de Daratrine. Ela muda a forma como o desenvolvimento é registrado: commits e PRs passam a preservar o que mudou para o jogador, como a entrega foi validada e quais momentos podem virar imagens ou vídeos de devlog.

## A experiência: antes e agora

**Antes:**

Mensagens como “ajustes”, “polimento” ou descrições centradas em arquivos dificultavam reconstruir o efeito real de uma entrega no jogo.

**Agora:**

O histórico orienta autores e agentes de IA a descrever o antes, o resultado observável, a relevância para a experiência e as evidências disponíveis.

**Por que isso importa:**

O material necessário para entender a evolução do jogo e roteirizar devlogs fica preservado no momento em que cada mudança é entregue.

## O que este PR entrega

- Template de commit com experiência do jogador, validação, bastidores, material de devlog e limitações.
- Template automático de PR com roteiro antes/agora, instruções para experimentar, evidências e kit de devlog.
- Guia de contribuição com ativação do template e exemplo preenchido.
- Regras para agentes de IA não inventarem impacto, playtest, captura ou validação.

## Como experimentar

1. Execute o comando de ativação documentado em `CONTRIBUTING.md`.
2. Inicie um commit sem `-m` e confira o conteúdo de `.gitmessage`.
3. Abra um novo PR no GitHub e confira o template carregado automaticamente.

## Validação

- [x] Os arquivos Markdown passaram no Prettier.
- [x] O template de commit foi processado com o filtro de comentários do Git.
- [x] O diff passou em `git diff --check`.
- [ ] Playtest no RPG Maker MZ — não aplicável; não há mudança no jogo.

## Fora deste PR

- Cada clone precisa ativar o template de commit uma vez.
- Clientes que criam commits com `-m` não abrem o template; por isso o `AGENTS.md` também registra a regra para ferramentas de IA.

## Kit de devlog

**Gancho em uma frase:**

“O histórico de Daratrine agora conta o que mudou no jogo, em vez de apenas listar o que mudou no código.”

**História curta da mudança:**

1. O histórico técnico não preservava facilmente a experiência entregue.
2. Os templates foram desenhados a partir do olhar do jogador.
3. Validações não executadas e impactos indiretos precisam ser declarados com honestidade.
4. Cada PR passa a reunir evidências e sugestões de captura para futuros devlogs.

**Capturas sugeridas:**

- Uma mensagem antiga centrada apenas em “ajustes” ou “polimento”.
- O novo template de commit preenchido.
- A seção “Kit de devlog” deste PR.
- Uma comparação antes/depois da descrição de uma entrega.

## Bastidores técnicos

- Base: `develop` atualizada em `576778cd`.
- Branch: `agent/player-facing-commit-pr-templates`.
- Commit: `3c2bc367`.
